### PR TITLE
Set bottom layout constraint priority lower

### DIFF
--- a/SelfSizingAutoLayoutCell/SelfSizingAutoLayoutCell.m
+++ b/SelfSizingAutoLayoutCell/SelfSizingAutoLayoutCell.m
@@ -47,7 +47,9 @@ NS_ASSUME_NONNULL_BEGIN
     [constraints addObject:[autolayoutView.topAnchor constraintEqualToAnchor:self.contentView.topAnchor constant:10.0]];
     [constraints addObject:[autolayoutView.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:10.0]];
     [constraints addObject:[self.contentView.trailingAnchor constraintEqualToAnchor:autolayoutView.trailingAnchor constant:10.0]];
-    [constraints addObject:[self.contentView.bottomAnchor constraintEqualToAnchor:autolayoutView.bottomAnchor constant:10.0]];
+    __auto_type bottomConstraint = [self.contentView.bottomAnchor constraintEqualToAnchor:autolayoutView.bottomAnchor constant:10.0];
+    bottomConstraint.priority = UILayoutPriorityDefaultHigh;
+    [constraints addObject:bottomConstraint];
 
     [NSLayoutConstraint activateConstraints:constraints];
 }

--- a/SelfSizingAutoLayoutCell/SelfSizingAutoLayoutCell.m
+++ b/SelfSizingAutoLayoutCell/SelfSizingAutoLayoutCell.m
@@ -55,6 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setIndex:(NSUInteger)index
 {
     self.autolayoutView.index = index;
+    [self.autolayoutView layoutIfNeeded];
 }
 
 - (NSUInteger)index

--- a/SelfSizingAutoLayoutCell/SelfSizingAutoLayoutCell.m
+++ b/SelfSizingAutoLayoutCell/SelfSizingAutoLayoutCell.m
@@ -57,6 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setIndex:(NSUInteger)index
 {
     self.autolayoutView.index = index;
+    [self.autolayoutView setNeedsLayout];
     [self.autolayoutView layoutIfNeeded];
 }
 

--- a/SelfSizingAutoLayoutCell/SelfSizingAutoLayoutCell.m
+++ b/SelfSizingAutoLayoutCell/SelfSizingAutoLayoutCell.m
@@ -65,13 +65,6 @@ NS_ASSUME_NONNULL_BEGIN
     return self.autolayoutView.index;
 }
 
-- (void)prepareForReuse
-{
-    [super prepareForReuse];
-
-    self.index = 0;
-}
-
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Because UITableView caches each cells' height, it's needed to weakify a vertical constraint not to break auto layout constraints.